### PR TITLE
Fix: gazebo simulation fails to start because of gazebo_ros2_control error

### DIFF
--- a/jackal_description/launch/description.launch.py
+++ b/jackal_description/launch/description.launch.py
@@ -1,37 +1,55 @@
 from launch import LaunchDescription
-from launch.actions import DeclareLaunchArgument
+from launch.actions import DeclareLaunchArgument, OpaqueFunction
 from launch.substitutions import Command, FindExecutable, PathJoinSubstitution, LaunchConfiguration
 
 from launch_ros.actions import Node
 from launch_ros.parameter_descriptions import ParameterValue
 from launch_ros.substitutions import FindPackageShare
 
+import re
+
+
+def launch_robot_description(context, ld, robot_description_parameter: ParameterValue):
+    robot_description = robot_description_parameter.evaluate(context)
+    print(type(robot_description))
+    pattern = r"<!--(.*?)-->"
+    robot_description_content = re.sub(pattern, "", robot_description, flags=re.DOTALL)
+
+    ld.add_action(
+        Node(
+            package="robot_state_publisher",
+            executable="robot_state_publisher",
+            parameters=[
+                {
+                    "robot_description": robot_description_content,
+                }
+            ],
+        )
+    )
+
 
 def generate_launch_description():
 
-    robot_description_command_arg = DeclareLaunchArgument(
-        'robot_description_command',
-        default_value=[
-            PathJoinSubstitution([FindExecutable(name='xacro')]),
-            ' ',
-            PathJoinSubstitution(
-                [FindPackageShare('jackal_description'), 'urdf', 'jackal.urdf.xacro']
-            )
-        ]
-    )
-
-    robot_description_content = ParameterValue(
-        Command(LaunchConfiguration('robot_description_command')),
-        value_type=str
-    )
-
-    robot_state_publisher_node = Node(package='robot_state_publisher',
-                                      executable='robot_state_publisher',
-                                      parameters=[{
-                                          'robot_description': robot_description_content,
-                                      }])
-
     ld = LaunchDescription()
+
+    robot_description_command_arg = DeclareLaunchArgument(
+        "robot_description_command",
+        default_value=[
+            PathJoinSubstitution([FindExecutable(name="xacro")]),
+            " ",
+            PathJoinSubstitution([FindPackageShare("jackal_description"), "urdf", "jackal.urdf.xacro"]),
+        ],
+    )
+
+    robot_description_parameter = ParameterValue(
+        Command(LaunchConfiguration("robot_description_command")), value_type=str
+    )
+
+    # robot_description_content = ParameterValue(
+    #     Command(LaunchConfiguration('robot_description_command')),
+    #     value_type=str
+    # )
+
     ld.add_action(robot_description_command_arg)
-    ld.add_action(robot_state_publisher_node)
+    ld.add_action(OpaqueFunction(function=launch_robot_description, args=[ld, robot_description_parameter]))
     return ld

--- a/jackal_description/urdf/jackal.gazebo
+++ b/jackal_description/urdf/jackal.gazebo
@@ -142,10 +142,10 @@
   </xacro:if>
 
   <gazebo>
-    <plugin name="gazebo_ros_p3d" filename="libgazebo_ros_pose3d.so">
+    <plugin name="gazebo_ros_p3d" filename="libgazebo_ros_p3d.so">
         <ros>
           <namespace>/jackal</namespace>
-          <!-- <remapping>odom</remapping> -->
+          <remapping>odom:=ground_truth</remapping>
         </ros>
         <frame_name>map</frame_name>
         <body_name>base_link</body_name>


### PR DESCRIPTION
- Fix the problem of gazebo_ros2_control crashing as decribed in issue [#295](https://github.com/ros-controls/gazebo_ros2_control/issues/295) of gazebo_ros2_control. 
  - Problem have been fixed by removing all the comments in the generated urdf as described [here](https://github.com/ros-controls/gazebo_ros2_control/issues/295#issuecomment-2031633887).

- "libgazebo_ros_pose3d" is substituted with the correct "libgazebo_ros_p3d"